### PR TITLE
Fix gitignore1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build*
+/build*/
 /.settings/
 /.cproject
 /.project

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.settings/
 /.cproject
 /.project
+/.vscode
 /googletest-release-1.8.0/


### PR DESCRIPTION
* Allow files starting with build. e.g. build-instructions.txt
* ignore settings from VS code
