### PR TITLE
CI compiler upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,16 +137,6 @@ matrix:
             - clang-8
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++
-    - compiler: clang-9
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-9
-          packages:
-            - clang-9
-            - libunwind8-dev
-      env: MYCC=clang MYCXX=clang++
     - compiler: clang-7
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 
 matrix:
   include:
-    - compiler: gcc
+    - compiler: gcc 4.8
       addons:
         apt:
           sources:
@@ -12,7 +12,7 @@ matrix:
             - g++-4.8
             - libunwind8-dev
       env: MYCC=gcc-4.8 MYCXX=g++-4.8
-    - compiler: gcc
+    - compiler: gcc 5
       addons:
         apt:
           sources:
@@ -21,7 +21,7 @@ matrix:
             - g++-5
             - libunwind8-dev
       env: MYCC=gcc-5 MYCXX=g++-5
-    - compiler: gcc
+    - compiler: gcc 6
       addons:
         apt:
           sources:
@@ -30,7 +30,7 @@ matrix:
             - g++-6
             - libunwind8-dev
       env: MYCC=gcc-6 MYCXX=g++-6
-    - compiler: gcc
+    - compiler: gcc 7
       addons:
         apt:
           sources:
@@ -39,7 +39,7 @@ matrix:
             - g++-7
             - libunwind8-dev
       env: MYCC=gcc-7 MYCXX=g++-7
-    - compiler: gcc
+    - compiler: gcc 8
       addons:
         apt:
           sources:
@@ -48,7 +48,16 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8
-    - compiler: gcc
+    - compiler: gcc 9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+            - libunwind8-dev
+      env: MYCC=gcc-9 MYCXX=g++-9
+    - compiler: gcc 7 (code cov)
       addons:
         apt:
           sources:
@@ -58,7 +67,7 @@ matrix:
             - libunwind8-dev
             - lcov
       env: MYCC=gcc-7 MYCXX=g++-7 CODE_COVERAGE=on
-    - compiler: clang
+    - compiler: clang 3.8
       addons:
         apt:
           sources:
@@ -68,7 +77,7 @@ matrix:
             - clang-3.8
             - libunwind8-dev
       env: MYCC=clang-3.8 MYCXX=clang++-3.8
-    - compiler: clang
+    - compiler: clang 3.9
       addons:
         apt:
           sources:
@@ -78,7 +87,7 @@ matrix:
             - clang-3.9
             - libunwind8-dev
       env: MYCC=clang-3.9 MYCXX=clang++-3.9
-    - compiler: clang
+    - compiler: clang 4
       addons:
         apt:
           sources:
@@ -88,7 +97,7 @@ matrix:
             - clang-4.0
             - libunwind8-dev
       env: MYCC=clang-4.0 MYCXX=clang++-4.0
-    - compiler: clang
+    - compiler: clang 5
       addons:
         apt:
           sources:
@@ -98,7 +107,7 @@ matrix:
             - clang-5.0
             - libunwind8-dev
       env: MYCC=clang-5.0 MYCXX=clang++-5.0
-    - compiler: clang
+    - compiler: clang 6
       addons:
         apt:
           sources:
@@ -108,7 +117,7 @@ matrix:
             - clang-6.0
             - libunwind8-dev
       env: MYCC=clang-6.0 MYCXX=clang++-6.0
-    - compiler: clang-7
+    - compiler: clang 7
       addons:
         apt:
           sources:
@@ -118,7 +127,27 @@ matrix:
             - clang-7
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++
-    - compiler: clang
+    - compiler: clang 8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-8
+          packages:
+            - clang-8
+            - libunwind8-dev
+      env: MYCC=clang MYCXX=clang++
+    - compiler: clang 9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-9
+          packages:
+            - clang-9
+            - libunwind8-dev
+      env: MYCC=clang MYCXX=clang++
+    - compiler: clang 7 (UBSAN)
       addons:
         apt:
           sources:
@@ -128,7 +157,7 @@ matrix:
             - clang-7
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++ ENABLE_UBSAN=on
-    - compiler: gcc
+    - compiler: gcc 8 (ASAN)
       addons:
         apt:
           sources:
@@ -137,7 +166,7 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8 ENABLE_ASAN=on
-    - compiler: gcc
+    - compiler: gcc 8 (TSAN)
       addons:
         apt:
           sources:
@@ -146,7 +175,7 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8 ENABLE_TSAN=on
-    - compiler: gcc
+    - compiler: gcc (MinGW)
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 
 matrix:
   include:
-    - compiler: gcc 4.8
+    - compiler: gcc-4.8
       addons:
         apt:
           sources:
@@ -12,7 +12,7 @@ matrix:
             - g++-4.8
             - libunwind8-dev
       env: MYCC=gcc-4.8 MYCXX=g++-4.8
-    - compiler: gcc 5
+    - compiler: gcc-5
       addons:
         apt:
           sources:
@@ -21,7 +21,7 @@ matrix:
             - g++-5
             - libunwind8-dev
       env: MYCC=gcc-5 MYCXX=g++-5
-    - compiler: gcc 6
+    - compiler: gcc-6
       addons:
         apt:
           sources:
@@ -30,7 +30,7 @@ matrix:
             - g++-6
             - libunwind8-dev
       env: MYCC=gcc-6 MYCXX=g++-6
-    - compiler: gcc 7
+    - compiler: gcc-7
       addons:
         apt:
           sources:
@@ -39,7 +39,7 @@ matrix:
             - g++-7
             - libunwind8-dev
       env: MYCC=gcc-7 MYCXX=g++-7
-    - compiler: gcc 8
+    - compiler: gcc-8
       addons:
         apt:
           sources:
@@ -48,7 +48,7 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8
-    - compiler: gcc 9
+    - compiler: gcc-9
       addons:
         apt:
           sources:
@@ -57,7 +57,7 @@ matrix:
             - g++-9
             - libunwind8-dev
       env: MYCC=gcc-9 MYCXX=g++-9
-    - compiler: gcc 7 (code cov)
+    - compiler: gcc-7
       addons:
         apt:
           sources:
@@ -67,7 +67,7 @@ matrix:
             - libunwind8-dev
             - lcov
       env: MYCC=gcc-7 MYCXX=g++-7 CODE_COVERAGE=on
-    - compiler: clang 3.8
+    - compiler: clang-3.8
       addons:
         apt:
           sources:
@@ -77,7 +77,7 @@ matrix:
             - clang-3.8
             - libunwind8-dev
       env: MYCC=clang-3.8 MYCXX=clang++-3.8
-    - compiler: clang 3.9
+    - compiler: clang-3.9
       addons:
         apt:
           sources:
@@ -87,7 +87,7 @@ matrix:
             - clang-3.9
             - libunwind8-dev
       env: MYCC=clang-3.9 MYCXX=clang++-3.9
-    - compiler: clang 4
+    - compiler: clang-4.0
       addons:
         apt:
           sources:
@@ -97,7 +97,7 @@ matrix:
             - clang-4.0
             - libunwind8-dev
       env: MYCC=clang-4.0 MYCXX=clang++-4.0
-    - compiler: clang 5
+    - compiler: clang-5.0
       addons:
         apt:
           sources:
@@ -107,7 +107,7 @@ matrix:
             - clang-5.0
             - libunwind8-dev
       env: MYCC=clang-5.0 MYCXX=clang++-5.0
-    - compiler: clang 6
+    - compiler: clang-6.0
       addons:
         apt:
           sources:
@@ -117,7 +117,7 @@ matrix:
             - clang-6.0
             - libunwind8-dev
       env: MYCC=clang-6.0 MYCXX=clang++-6.0
-    - compiler: clang 7
+    - compiler: clang-7
       addons:
         apt:
           sources:
@@ -127,7 +127,7 @@ matrix:
             - clang-7
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++
-    - compiler: clang 8
+    - compiler: clang-8
       addons:
         apt:
           sources:
@@ -137,7 +137,7 @@ matrix:
             - clang-8
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++
-    - compiler: clang 9
+    - compiler: clang-9
       addons:
         apt:
           sources:
@@ -147,7 +147,7 @@ matrix:
             - clang-9
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++
-    - compiler: clang 7 (UBSAN)
+    - compiler: clang-7
       addons:
         apt:
           sources:
@@ -157,7 +157,7 @@ matrix:
             - clang-7
             - libunwind8-dev
       env: MYCC=clang MYCXX=clang++ ENABLE_UBSAN=on
-    - compiler: gcc 8 (ASAN)
+    - compiler: gcc-8
       addons:
         apt:
           sources:
@@ -166,7 +166,7 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8 ENABLE_ASAN=on
-    - compiler: gcc 8 (TSAN)
+    - compiler: gcc-8
       addons:
         apt:
           sources:
@@ -175,7 +175,7 @@ matrix:
             - g++-8
             - libunwind8-dev
       env: MYCC=gcc-8 MYCXX=g++-8 ENABLE_TSAN=on
-    - compiler: gcc (MinGW)
+    - compiler: x86_64-w64-mingw32-g++
       addons:
         apt:
           packages:

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -139,7 +139,7 @@ OOOPSI_FORCE_INLINE size_t collectStackTrace(Func&& handler,
 static void logFrame(const LogSettings settings, uint64_t num, pointer_t address, const char* sym,
                      uint64_t offset, const pointer_t* faultAddr)
 {
-    char messageBuffer[512];
+    char messageBuffer[1024];
     const char* prefix = "  ";
     if (faultAddr != nullptr && *faultAddr == address)
     {
@@ -161,8 +161,15 @@ static void logFrame(const LogSettings settings, uint64_t num, pointer_t address
             }
             else
             {
-                // copy the plain name
+                // copy the plain name (may get truncated)
+#ifdef OOOPSI_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
                 strncat(messageBuffer, sym, sizeof(messageBuffer) - bufLen - 1);
+#ifdef OOOPSI_GCC
+#pragma GCC diagnostic pop
+#endif
             }
             bufLen = strlen(messageBuffer);
         }

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -164,6 +164,7 @@ static void logFrame(const LogSettings settings, uint64_t num, pointer_t address
                 // copy the plain name (may get truncated)
 #ifdef OOOPSI_GCC
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragma"
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
                 strncat(messageBuffer, sym, sizeof(messageBuffer) - bufLen - 1);

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -164,7 +164,7 @@ static void logFrame(const LogSettings settings, uint64_t num, pointer_t address
                 // copy the plain name (may get truncated)
 #ifdef OOOPSI_GCC
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragma"
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
                 strncat(messageBuffer, sym, sizeof(messageBuffer) - bufLen - 1);

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -37,6 +37,7 @@ namespace ooopsi
 {
 
 #ifdef OOOPSI_WINDOWS
+// access to the debug help API must be serialized
 DbgHelpMutex s_dbgHelpMutex;
 #endif
 


### PR DESCRIPTION
Added GCC 8 + Clang 8 to Travis CI
With GCC 8, a new compiler warning shows up, notifying about a possible string truncation. Since the code uses limited stack buffers, this is expected and is now suppressed.